### PR TITLE
Export RDT Store 

### DIFF
--- a/packages/react-devtools-inline/replay.js
+++ b/packages/react-devtools-inline/replay.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/replay');

--- a/packages/react-devtools-inline/src/replay.js
+++ b/packages/react-devtools-inline/src/replay.js
@@ -1,3 +1,3 @@
 /** @flow */
 
-export {default as Store} from 'react-devtools-shared/src/devtools/store';
+export {Store} from 'react-devtools-shared/src/devtools/store';

--- a/packages/react-devtools-inline/src/replay.js
+++ b/packages/react-devtools-inline/src/replay.js
@@ -1,0 +1,4 @@
+/** @flow */
+
+export {default as Store} from 'react-devtools-shared/src/devtools/store';
+export {printStore} from 'react-devtools-shared/src/devtools/utils';

--- a/packages/react-devtools-inline/src/replay.js
+++ b/packages/react-devtools-inline/src/replay.js
@@ -1,4 +1,3 @@
 /** @flow */
 
 export {default as Store} from 'react-devtools-shared/src/devtools/store';
-export {printStore} from 'react-devtools-shared/src/devtools/utils';

--- a/packages/react-devtools-inline/webpack.config.js
+++ b/packages/react-devtools-inline/webpack.config.js
@@ -40,6 +40,7 @@ module.exports = {
     backend: './src/backend.js',
     frontend: './src/frontend.js',
     hookNames: './src/hookNames.js',
+    replay: './src/replay.js'
   },
   output: {
     path: __dirname + '/dist',


### PR DESCRIPTION
Draft PR for visibility. Exports RDT `Store` class from `@replayio/react-devtools-inline` through a `replay` entrypoint